### PR TITLE
cypress 5.2.0

### DIFF
--- a/test/cypress/cypress.json
+++ b/test/cypress/cypress.json
@@ -6,5 +6,5 @@
   "watchForFileChanges": false,
   "numTestsKeptInMemory": 0,
   "retries": 4,
-  "experimentalShadowDomSupport": true
+  "includeShadowDom": true
 }

--- a/test/cypress/cypress/integration/products_spec.js
+++ b/test/cypress/cypress/integration/products_spec.js
@@ -9,9 +9,9 @@ describe("Products", function () {
 
     cy.getTag("product-list")
     cy.getTag("produx-box").its('length').then(($lenght) => {
-     const listElementNumber = randomGenerator($lenght);
-     cy.getTag('produx-box').eq(listElementNumber).click()
-     cy.get("dershop-product", {includeShadowDom: true})
+      const listElementNumber = randomGenerator($lenght);
+      cy.getTag('produx-box').eq(listElementNumber).click()
+      cy.get("dershop-product")
     });
 
   });
@@ -21,23 +21,23 @@ describe("Products", function () {
 
     cy.visit("/products");
     cy.getTag("product-list")
-     cy.getTag("produx-box").its('length').then(($lenght) => {
+    cy.getTag("produx-box").its('length').then(($lenght) => {
       const listElementNumber = randomGenerator($lenght);
       cy.getTag('produx-box').eq(listElementNumber).click()
 
       cy.getTag("product-title").invoke("text").then((productTitle) => {
         cy.getTag("addToCart").click()
         cy.visit("/cart")
-        cy.getTag("cartItemName").invoke("text").should("be.equal",productTitle)
+        cy.getTag("cartItemName").invoke("text").should("be.equal", productTitle)
         cy.getTag("buy-now").click()
         cy.url().should("contain", "/account/order");
         cy.get("dershop-order-view")
       })
-     })
+    })
   });
 
-   //Function to generate random number 
-   const randomGenerator = (number) => {
+  //Function to generate random number 
+  const randomGenerator = (number) => {
     return Math.round(Math.random() * (number - 1))
   }
 });

--- a/test/cypress/cypress/support/commands.js
+++ b/test/cypress/cypress/support/commands.js
@@ -26,7 +26,7 @@
 import "cypress-file-upload";
 
 Cypress.Commands.add("getTag", (tag) => {
-  return cy.get('[data-cy="' + tag + '"]', {includeShadowDom: true});
+  return cy.get('[data-cy="' + tag + '"]');
 });
 
 Cypress.Commands.add("login", (email, password) => {

--- a/test/cypress/package.json
+++ b/test/cypress/package.json
@@ -9,7 +9,7 @@
     "cy:open": "cypress open --config watchForFileChanges=true"
   },
   "devDependencies": {
-    "cypress": "5.1.0",
+    "cypress": "5.2.0",
     "cypress-file-upload": "4.0.7",
     "faker": "5.1.0"
   }

--- a/test/cypress/yarn.lock
+++ b/test/cypress/yarn.lock
@@ -372,10 +372,10 @@ cypress-file-upload@4.0.7:
   dependencies:
     mime "^2.4.4"
 
-cypress@5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-5.1.0.tgz#979e9ff3e0acd792eefd365bf104046479a9643b"
-  integrity sha512-craPRO+Viu4268s7eBvX5VJW8aBYcAQT+EwEccQSMY+eH1ZPwnxIgyDlmMWvxLVX9SkWxOlZbEycPyzanQScBQ==
+cypress@5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-5.2.0.tgz#6902efd90703242a2539f0623c6e1118aff01f95"
+  integrity sha512-9S2spcrpIXrQ+CQIKHsjRoLQyRc2ehB06clJXPXXp1zyOL/uZMM3Qc20ipNki4CcNwY0nBTQZffPbRpODeGYQg==
   dependencies:
     "@cypress/listr-verbose-renderer" "^0.4.1"
     "@cypress/request" "^2.88.5"


### PR DESCRIPTION
https://docs.cypress.io/guides/references/changelog.html#5-2-0

_Added the configuration option includeShadowDom for enabling shadow DOM querying globally, per-suite, per-test, or programmatically. Addresses #8442._

https://github.com/cypress-io/cypress/pull/8548
