### PR TITLE
use apollo client lib for persisted queries

### DIFF
--- a/packages/plugins/core-components/app/store/core.ts
+++ b/packages/plugins/core-components/app/store/core.ts
@@ -1,11 +1,12 @@
 import { InMemoryCache } from '@apollo/client/cache';
 import { ApolloClient } from '@apollo/client/core';
+import { ErrorLink } from "@apollo/client/link/error";
 import { createHttpLink } from "@apollo/client/link/http";
-import { ErrorLink } from "@apollo/client/link/error"
-import { createPersistedQueryLink } from "@apollo/link-persisted-queries";
+import { createPersistedQueryLink } from "@apollo/client/link/persisted-queries";
 import { Build } from "@stencil/core";
 import { createStore } from "@stencil/store";
-import { Components } from "../components"
+import { sha256 } from 'crypto-hash';
+import { Components } from "../components";
 import { FlashEvent, FlashTypes } from '../utils/events';
 
 let client;
@@ -50,15 +51,13 @@ if (Build.isBrowser) {
     if (networkError) console.log(`[Network error]: ${networkError}`);
   })
 
-  const link = createPersistedQueryLink({ useGETForHashedQueries: true })
-    //@ts-ignore
-    .concat(errorLink)
-    //@ts-ignore
-    .concat(httpLink)
+  const link = createPersistedQueryLink({
+    useGETForHashedQueries: true,
+    sha256
+  }).concat(errorLink).concat(httpLink)
 
   client = new ApolloClient({
     cache: new InMemoryCache(),
-    //@ts-ignore
     link
   });
 }

--- a/packages/plugins/core-components/package.json
+++ b/packages/plugins/core-components/package.json
@@ -73,9 +73,9 @@
   },
   "dependencies": {
     "@apollo/client": "3.3.6",
-    "@apollo/link-persisted-queries": "https://github.com/corejam/apollo-link-persisted-queries/tarball/master",
     "@corejam/rollup-plugin": "0.0.3",
     "@corejam/router": "0.0.7",
+    "crypto-hash": "1.3.0",
     "graphql-tag": "2.11.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -123,13 +123,6 @@
     tslib "^1.10.0"
     zen-observable "^0.8.14"
 
-"@apollo/link-persisted-queries@https://github.com/corejam/apollo-link-persisted-queries/tarball/master":
-  version "0.2.2"
-  resolved "https://github.com/corejam/apollo-link-persisted-queries/tarball/master#9a37b90078382522589c3ad4138f914d04655b5f"
-  dependencies:
-    apollo-link "^1.2.1"
-    hash.js "^1.1.3"
-
 "@apollo/protobufjs@^1.0.3":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@apollo/protobufjs/-/protobufjs-1.0.5.tgz#a78b726147efc0795e74c8cb8a11aafc6e02f773"
@@ -3235,7 +3228,7 @@ apollo-graphql@^0.6.0:
     apollo-env "^0.6.5"
     lodash.sortby "^4.7.0"
 
-apollo-link@^1.2.1, apollo-link@^1.2.14:
+apollo-link@^1.2.14:
   version "1.2.14"
   resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.14.tgz#3feda4b47f9ebba7f4160bef8b977ba725b684d9"
   integrity sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==
@@ -5081,6 +5074,11 @@ crypto-browserify@3.12.0, crypto-browserify@^3.11.0:
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
     randomfill "^1.0.3"
+
+crypto-hash@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/crypto-hash/-/crypto-hash-1.3.0.tgz#b402cb08f4529e9f4f09346c3e275942f845e247"
+  integrity sha512-lyAZ0EMyjDkVvz8WOeVnuCPvKVBXcMv1l5SVqO1yC7PzTwrD/pPje/BIRbWhMoPe436U+Y2nD7f5bFx0kt+Sbg==
 
 css-loader@4.3.0:
   version "4.3.0"
@@ -7200,7 +7198,7 @@ hash-base@^3.0.0:
     readable-stream "^3.6.0"
     safe-buffer "^5.2.0"
 
-hash.js@^1.0.0, hash.js@^1.0.3, hash.js@^1.1.3:
+hash.js@^1.0.0, hash.js@^1.0.3:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
   integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==


### PR DESCRIPTION
Due to `apollo-link-persisted-queries` having been moved over to the `@apollo/client` lib we can deprecate our fork of the old lib and clean up some `@ts-ignore` tags as we now have valid types. 

We can also delete our fork once we have merged into master