### PR TITLE
remove build from publish step

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -401,7 +401,6 @@ jobs:
 
       - name: 🚽 Publish package
         run: |
-          yarn build
           yarn logout
           npm whoami
           yarn lerna publish --yes $LERNA_TAG --no-verify-access $CANARY

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -35,9 +35,7 @@
     "precommit": "lint-staged",
     "clean": "rimraf dist & rimraf react & rimraf web-components",
     "static": "corejam static",
-    "static:serve": "corejam static:serve",
-    "prepublish": "shx rm -f .env && yarn clean && yarn build",
-    "postpublish": "shx cp .env.sample .env"
+    "static:serve": "corejam static:serve"
   },
   "files": [
     "dist",

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -37,8 +37,7 @@
     "build": "tsc -p tsconfig.json && tsc -p tsconfig-cjs.json",
     "test": "jest --verbose --config=./jest.config.js",
     "clean": "rimraf dist",
-    "precommit": "lint-staged",
-    "prepublish": "yarn clean && yarn build"
+    "precommit": "lint-staged"
   },
   "devDependencies": {
     "@types/faker": "5.1.7",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,8 +32,7 @@
     "build": "tsc",
     "postbuild": "shx cp -r ./src/templates ./dist && lerna link",
     "test": "jest",
-    "clean": "rimraf dist",
-    "prepublish": "yarn clean && yarn build"
+    "clean": "rimraf dist"
   },
   "dependencies": {
     "@corejam/base": "0.0.14",

--- a/packages/core-components/package.json
+++ b/packages/core-components/package.json
@@ -31,9 +31,7 @@
     "precommit": "lint-staged",
     "static": "corejam static",
     "static:serve": "corejam static:serve",
-    "clean": "rimraf dist & rimraf react & rimraf web-components",
-    "prepublish": "shx rm -f .env && yarn clean && yarn build",
-    "postpublish": "shx cp .env.sample .env"
+    "clean": "rimraf dist & rimraf react & rimraf web-components"
   },
   "files": [
     "web-components",

--- a/packages/dershop/package.json
+++ b/packages/dershop/package.json
@@ -37,9 +37,7 @@
     "precommit": "lint-staged",
     "static": "corejam static",
     "static:serve": "corejam static:serve",
-    "clean": "rimraf dist & rimraf react & rimraf web-components",
-    "prepublish": "shx rm -f .env && yarn clean && yarn build",
-    "postpublish": "shx cp .env.sample .env"
+    "clean": "rimraf dist & rimraf react & rimraf web-components"
   },
   "files": [
     "dist",

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -10,8 +10,7 @@
   ],
   "scripts": {
     "build": "rollup --config rollup.config.js",
-    "clean": "rimraf dist",
-    "prepublish": "yarn clean && yarn build"
+    "clean": "rimraf dist"
   },
   "devDependencies": {
     "fs-jetpack": "4.1.0",


### PR DESCRIPTION
Due to the change in https://github.com/corejam/corejam/commit/4f5a7bc5ee519ad292f2d26546f1f77774701bbf#diff-014228303dff9a1af15f4bbd18401f906380129b10ae2a2c62f8b8be592ff88eR41 we now throw everything inside /packages into the artifact which should mean we no longer need the build step in the publish action? @patrickhaug 

We shouldn't be publishing locally so we can remove the prepublish / postpublish steps.